### PR TITLE
Cheat sheet for moving from Quarkus 2 to Quarkus 3

### DIFF
--- a/docs/Home.md
+++ b/docs/Home.md
@@ -56,37 +56,42 @@ mvn io.quarkus:quarkus-maven-plugin:create-extension \
 
 The Quarkiverse team will provide the repository ready for development, nevertheless, it is always good to know that we respect the following conventions and policies. 
 
-## Identify Project Maintainer ##
+### Identify Project Maintainer ##
 
 Each project will have a GitHub team, and in here at least one must be listed and active as maintainer. This is the person that will be expected to lead and drive the project.
 
-## Repository name
+### Repository name
 
 The repository name under the quarkiverse organization should have `quarkus-` prefix. This will help avoid potential conflicts when cloning and/or forking the repository.
 
-## Project's Maven artifact `groupId`s
+### Project's Maven artifact `groupId`s
 
 The Maven `groupId` of the project's artifacts should follow the following format: `io.quarkiverse.<project-name>`. In other words, the project’s `groupId` should start with the `io.quarkiverse.` prefix followed by the project-specific unique name (minus the `quarkus-` prefix) in which dots aren't allowed. Also, since your `groupId` should also be your root package name, if it contains characters that are not allowed in package names (such as `-`), you should concatenate all the parts of your project name to form a single, lowercased name. So if your repository is named `quarkus-foo-bar`, your `groupId` would become `io.quarkiverse.foobar`.
 
-## Project's Maven artifact `artifactId`s
+### Project's Maven artifact `artifactId`s
 
 The project’s `artifactId` should start with the `quarkus-` prefix.
 
-## Root package name
+### Root package name
 
 The root package name is expected to be the same as the project’s Maven artifact `groupId`, i.e. `io.quarkiverse.jberet`, if project name is `jberet`. See the [`groupId` section](#projects-maven-artifact-groupids) for more details. 
 
-## Parent POM
+### Parent POM
 
 All Quarkiverse projects are expected to use [io.quarkiverse:quarkiverse-parent](https://github.com/quarkiverse/quarkiverse-parent) as the parent POM.
 This POM contains common project release and artifact publishing configuration.
 
-## Provide mechanism to do cross-testing of named quarkus core and platform versions
+### Provide mechanism to do cross-testing of named quarkus core and platform versions
 
 All Quarkiverse projects should have a build and test suite that can be parameterized to use specific Quarkus and Platform versions to ensure we can get
 early warning of issues of master builds; but also to verify compatibiltiy with maintanence branch/tags.
 
 Mechanism is To be defined, but something like having a script that will take quarkus core and quarkus platform Group, Artifact and IDs.
+
+## Documenting your extension
+
+Consider adding documentation to the [Quarkiverse docs page](https://quarkiverse.github.io/quarkiverse-docs/index/index/index.html). 
+You can submit changes via github](https://github.com/quarkiverse/quarkiverse-docs).
 
 ## LICENSE
 

--- a/docs/Quarkus2to3Migration.md
+++ b/docs/Quarkus2to3Migration.md
@@ -23,7 +23,7 @@ Note that the Jakarta changes are available in the Quarkus 3.0.0.Alpha1 release,
 
 # Are you affected?
 
-Our analysis found that all but one or two extensions in the Quarkiverse are affected by these changes. If you want to check if changes are needed, you can either run the migration scripts and see what’s changed, or grep your codebase for the following
+Our analysis found that all but one or two extensions in the Quarkiverse are affected by these changes. If you want to check if changes are needed, you can either run the [migration scripts](#upgrade) and see what’s changed, or grep your codebase for the following
 - `javax` (if you have code, you almost certainly have this)
 - `org.reactivestreams`
 - `hibernate`

--- a/docs/Quarkus2to3Migration.md
+++ b/docs/Quarkus2to3Migration.md
@@ -60,10 +60,18 @@ git am ../19.patch
 
 # Upgrade
 
-To make updating reliable and simple, the team has written an Open Rewrite script. To run it via jbang (and curl):
+To make updating reliable and simple, the team has written an Open Rewrite script. You can run it via jbang (and curl).
+
+For Linux:
 
 ```
 curl -Ls https://sh.jbang.dev | bash -s - --fresh upgrade-to-quarkus3@quarkusio
+```
+
+For Windows:
+
+```
+iex "& { $(iwr https://ps.jbang.dev) } --fresh upgrade-to-quarkus3@quarkusio"
 ```
 
 Alternatively, you can [download the recipe](https://github.com/quarkusio/quarkus/blob/main/jakarta/quarkus3.yml) and then run

--- a/docs/Quarkus2to3Migration.md
+++ b/docs/Quarkus2to3Migration.md
@@ -1,0 +1,166 @@
+# What’s changing
+[Quarkus 3 is on the way](https://quarkus.io/blog/road-to-quarkus-3/), and it has breaking changes. 
+These changes will affect extensions, so extension maintainers should be prepared. 
+
+# Here are the known breakers:
+
+## Java EE to Jakarta [released now]
+Quarkus is moving to use Jakarta APIs rather than Java EE ones. In most cases the functionality isn’t different, but package names are.
+
+## Hibernate ORM 5 to 6 [coming soon]
+
+Quarkus 3 will ship with Hibernate ORM 6 instead of Hibernate ORM 5. This is major release, and so there are some breaking changes, especially if your extension uses the Criteria API. We don’t expect that many extensions rely on these, but in case you do, the Hibernate team have published a full migration guide.
+
+## Flow, instead of reactive streams [coming soon]
+Quarkus 3 uses the JDK Flow API introduced since Java 9 instead of the legacy Reactive Streams API.
+For a discussion of what changes were needed within Quarkus itself, see
+- https://groups.google.com/g/quarkus-dev/c/RpeqFv1dr8k
+- https://github.com/quarkusio/quarkus/issues/26675
+
+If your extension needs to use a library that is still using the legacy Reactive Streams API then you should use the adapters from the Mutiny Zero project (see https://smallrye.io/smallrye-mutiny-zero).
+
+Note that the Jakarta changes are available in the Quarkus 3.0.0.Alpha1 release, but the Hibernate ORM and Flow changes are still under development.
+
+# Are you affected?
+
+Our analysis found that all but one or two extensions in the Quarkiverse are affected by these changes. If you want to check if changes are needed, you can either run the migration scripts and see what’s changed, or grep your codebase for the following
+- javax (if you have code, you almost certainly have this)
+- org.reactivestreams
+- hibernate
+
+Files like `persistence.xml` also need to be updated, but if you have those you almost certainly also have a javax.* dependency somewhere in the pom.xml or Java code.
+
+# When should you act?
+
+It’s worth thinking about how big an impact these changes will have on your extension. For some extensions it’s a trivial search and replace, but for other extensions the impact may be more complicated, particularly if you depend on libraries which have not yet made the move to Jakarta.
+
+We recommend starting to prepare now if getting to Quarkus 3 is complex. If the move is straightforward, you may wish to wait a while, so that you don’t need to maintain two branches for several months.
+
+# Implement the migration
+
+## Make your new branch
+
+In the main extension repo, set up a new branch for the legacy 2.x code stream. We recommend that ‘main’ is used for the 3.0 stream. For most extensions, a 2.0 and a 3.0 version should co-exist, at least for a while.
+
+The quarkus-snapshot.yaml inside each repository should somehow parameterize the call to `setup-and-test` specifying that the main branch is 3.x and not 2.x until the 3.x branch in quarkusio/quarkus is merged in main.
+We do not have a worked example of this yet!
+
+## Set up Github actions on the new branch
+
+### Workflow updates
+
+You will need to update the GitHub actions workflows to support releases from feature branches. The following PR illustrates the changes needed: https://github.com/quarkusio/quarkus/pull/28974
+
+For newer repositories, it may work to apply the following patch (if it fails to apply, that’s fine, just update by hand):
+
+```
+curl https://patch-diff.githubusercontent.com/raw/quarkiverse/quarkus-pact/pull/19.patch > ../19.patch
+git am ../19.patch
+```
+
+
+## Version updates
+
+At some point, in the main branch, update `.github/project.yml` with the versions for the 3.0 stream.
+
+For example,
+
+```
+release:
+  current-version: 3.0.0.Alpha3
+  next-version: 999-SNAPSHOT
+```
+You may want to choose different snapshot versions for 2.x and 3.x, to avoid confusing behaviour in your local maven repo. 
+
+However, merging this change will trigger a release, so do not merge until you're ready to release. 
+
+# Upgrade
+
+To make updating reliable and simple, the team has written an Open Rewrite script. To run it via jbang (and curl):
+
+```
+curl -Ls https://sh.jbang.dev | bash -s - --fresh upgrade-to-quarkus3@quarkusio
+```
+
+Alternatively, you can [download the recipe](https://github.com/quarkusio/quarkus/blob/main/jakarta/quarkus3.yml) and then run
+
+```
+mvn org.openrewrite.maven:rewrite-maven-plugin:4.36.0:run \
+-Drewrite.configLocation=[SOME_PATH]/quarkus3.yml \
+-DactiveRecipes=io.quarkus.openrewrite.Quarkus3
+```
+
+Don’t forget to migrate your codestart if you have one.
+
+## Alternate process: manual upgrade
+
+If you’re not able to use the automation or some step is missed, you can manually move to the latest dependencies and patch up the code manually.
+
+### Manual process, step 1: Upgrade your parent pom to the latest version of the quarkiverse-parent pom.
+
+Make sure you depend on the [latest version of the Quarkiverse parent](https://search.maven.org/search?q=a:quarkiverse-parent) (at least 11), as this ensures you will pick up any Quarkus-3-related support, such as enforcer changes and import ordering fixes.
+
+### Manual process, step 2: Update the Quarkus version
+
+Update the Quarkus dependencies in your pom.xml to depend on the latest 3.x  Quarkus. You can either
+
+- use the nightly snapshot, following the [instructions for using snapshots](https://github.com/quarkusio/quarkus/tree/main/jakarta#using-snapshots) 
+- depend on the latest release, 3.0.0.Alpha1
+
+Using the release is recommended unless you need something in the snapshots.
+
+To update the Quarkus version, update the property:
+
+```
+<quarkus.version>3.0.0.Alpha1</quarkus.version>
+```
+
+In the exceptional case that you are not using the platform BOM, the dependency would look like:
+
+```
+<dependency>
+  <groupId>io.quarkus</groupId>
+  <artifactId>quarkus-[your-dependency-here]</artifactId>
+  <version>3.0.0.Alpha1</version>
+</dependency>
+```
+
+In Gradle, it would be:
+
+```
+implementation 'io.quarkus:quarkus-[your-dependency-here]:3.0.0.Alpha1'
+```
+
+### Manual process, step 3: Get everything working
+
+At this point, if you build, you should see a lot of failures. 
+Resolving them will involve upgrading other dependencies to bring in versions which use Jakarta, and searching for javax.* references in the codebase. 
+
+Be aware that not all javax packages have been moved to Jakarta. (That's why using a tool is recommended.) 
+The Jakarta Eclipse Transformer (which only changes the source code, not the POM) is an alternative to the OpenRewrite recipe.
+
+## Declare your compatibilities
+
+If your extension has some non-standard compatibilities, follow the [compatibility documentation instructions](https://github.com/quarkusio/quarkus-extension-catalog#compatibility-with-older-quarkus-core-versions)  to update the extensions catalog with information about your new versions, and what versions of Quarkus they work with.
+
+## Testing
+
+This is a good time to think about testing. Does your project have integration tests? Are they running as part of the CI? If you don’t have a codestart, consider making one, because codestarts are great.
+
+To be extra-cautious, consider making a project which is based on Quarkus 3 to check the extension is working well. (If this fails and your CI is passing, it’s an indication that more automated integration tests might be needed.)
+
+# It’s all gone wrong! Help!
+This is a big change, and we’re expecting some rough bumps. If you hit issues, we’d love to hear about them, so we can either fix them, or figure out a workaround to share with other extensions.
+
+There are a few ways you can communicate with us:
+
+- Zulip. There is a [topic Quarkus 3 readiness for extensions](https://quarkusio.zulipchat.com/#narrow/stream/187038-dev/topic/Quarkus.203)
+- [Quarkus-dev mailing list](https://groups.google.com/g/quarkus-dev)
+
+Issues on the main Quarkus repo. Please @mention @maxandersen and @holly-cummins
+
+We’d also like to hear from you if things go well. We’ll be tracking the “all clears” so we can decide when it makes sense to move from 3.0.0 Alpha to a final release.
+
+# What’s Quarkus itself doing?
+
+https://github.com/quarkusio/quarkus/tree/main/jakarta has useful information on how the Quarkus core is working through the migration effort. 

--- a/docs/Quarkus2to3Migration.md
+++ b/docs/Quarkus2to3Migration.md
@@ -24,11 +24,11 @@ Note that the Jakarta changes are available in the Quarkus 3.0.0.Alpha1 release,
 # Are you affected?
 
 Our analysis found that all but one or two extensions in the Quarkiverse are affected by these changes. If you want to check if changes are needed, you can either run the migration scripts and see what’s changed, or grep your codebase for the following
-- javax (if you have code, you almost certainly have this)
-- org.reactivestreams
-- hibernate
+- `javax` (if you have code, you almost certainly have this)
+- `org.reactivestreams`
+- `hibernate`
 
-Files like `persistence.xml` also need to be updated, but if you have those you almost certainly also have a javax.* dependency somewhere in the pom.xml or Java code.
+Files like `persistence.xml` also need to be updated, but if you have those you almost certainly also have a `javax.*` dependency somewhere in the pom.xml or Java code.
 
 # When should you act?
 
@@ -57,22 +57,6 @@ For newer repositories, it may work to apply the following patch (if it fails to
 curl https://patch-diff.githubusercontent.com/raw/quarkiverse/quarkus-pact/pull/19.patch > ../19.patch
 git am ../19.patch
 ```
-
-
-## Version updates
-
-At some point, in the main branch, update `.github/project.yml` with the versions for the 3.0 stream.
-
-For example,
-
-```
-release:
-  current-version: 3.0.0.Alpha3
-  next-version: 999-SNAPSHOT
-```
-You may want to choose different snapshot versions for 2.x and 3.x, to avoid confusing behaviour in your local maven repo. 
-
-However, merging this change will trigger a release, so do not merge until you're ready to release. 
 
 # Upgrade
 
@@ -134,9 +118,9 @@ implementation 'io.quarkus:quarkus-[your-dependency-here]:3.0.0.Alpha1'
 ### Manual process, step 3: Get everything working
 
 At this point, if you build, you should see a lot of failures. 
-Resolving them will involve upgrading other dependencies to bring in versions which use Jakarta, and searching for javax.* references in the codebase. 
+Resolving them will involve upgrading other dependencies to bring in versions which use Jakarta, and searching for `javax.*` references in the codebase. 
 
-Be aware that not all javax packages have been moved to Jakarta. (That's why using a tool is recommended.) 
+Be aware that not all `javax` packages have been moved to Jakarta. (That's why using a tool is recommended.) 
 The Jakarta Eclipse Transformer (which only changes the source code, not the POM) is an alternative to the OpenRewrite recipe.
 
 ## Declare your compatibilities
@@ -148,6 +132,23 @@ If your extension has some non-standard compatibilities, follow the [compatibili
 This is a good time to think about testing. Does your project have integration tests? Are they running as part of the CI? If you don’t have a codestart, consider making one, because codestarts are great.
 
 To be extra-cautious, consider making a project which is based on Quarkus 3 to check the extension is working well. (If this fails and your CI is passing, it’s an indication that more automated integration tests might be needed.)
+
+
+# Version updates
+
+On your first release, bump your major version number in the 3.0 stream `.github/project.yml`.
+
+For example,
+
+```
+release:
+  current-version: 3.0.0.Alpha3
+  next-version: 999-SNAPSHOT
+```
+You may want to choose different snapshot versions for 2.x and 3.x, to avoid confusing behaviour in your local maven repo.
+
+(Don't forget that merging a change to `project.yml` will trigger a release, so do not merge until you're ready to release.)
+
 
 # It’s all gone wrong! Help!
 This is a big change, and we’re expecting some rough bumps. If you hit issues, we’d love to hear about them, so we can either fix them, or figure out a workaround to share with other extensions.


### PR DESCRIPTION
Also in this change is an older change I apparently forgot to do a PR for, to adjust the hierarchy of the home page and add a cross-link to the quarkiverse docs page.