### PR TITLE
Add a bit more documentation about writing documentation.

### DIFF
--- a/docs/Checklist.md
+++ b/docs/Checklist.md
@@ -30,7 +30,7 @@ issues:
 
 ## [Register the extension documentation in the quarkiverse-docs](https://github.com/quarkiverse/quarkiverse-docs)
 
-In order to have your extension documentation listed in the [Quarkiverse Documentation website](https://quarkiverse.github.io/quarkiverse-docs/), open a PR including it in the [antora-playbook.yml](https://github.com/quarkiverse/quarkiverse-docs/blob/main/antora-playbook.yml)
+In order to have your [extension documentation](https://github.com/quarkiverse/quarkiverse/wiki#documenting-your-extension) listed in the [Quarkiverse Documentation website](https://quarkiverse.github.io/quarkiverse-docs/), open a PR including it in the [antora-playbook.yml](https://github.com/quarkiverse/quarkiverse-docs/blob/main/antora-playbook.yml)
 
 ## [Make your extension available in the tooling](https://github.com/quarkusio/quarkus-extension-catalog#extensions)
 

--- a/docs/Home.md
+++ b/docs/Home.md
@@ -90,8 +90,17 @@ Mechanism is To be defined, but something like having a script that will take qu
 
 ## Documenting your extension
 
-Consider adding documentation to the [Quarkiverse docs page](https://quarkiverse.github.io/quarkiverse-docs/index/index/index.html).
-You can submit changes via [GitHub](https://github.com/quarkiverse/quarkiverse-docs).
+The Quarkiverse extension template includes skeleton documentation. 
+These docs use [Asciidoctor](https://asciidoctor.org/) for content, and [Antora](https://antora.org/) for navigation.
+To get started creating your documentation, update the `docs/modules/ROOT/pages/index.adoc` in your project.
+If your extension grows more complex and you need multiple pages, add them to `docs/modules/ROOT/nav.adoc`.
+
+Code samples can be put in the `docs/modules/ROOT/examples` folder, and imported into the main documentation with [an `::include` directive](https://docs.asciidoctor.org/asciidoc/latest/directives/include/).
+Properties in `docs/templates/includes/attributes.adoc` will be resolved and copied into `docs/modules/ROOT/pages/includes/attributes.adoc` by the Maven resources plugin each build.
+
+Consider adding documentation to the [Quarkiverse docs page](https://quarkiverse.github.io/quarkiverse-docs/index/index/index.html). 
+The Quarkiverse Hub uses [Antora](https://antora.org/) to aggregate each extension's documentation in the Quarkiverse docs website. 
+To register your extension's documentation, open a PR including it in the [antora-playbook.yml](https://github.com/quarkiverse/quarkiverse-docs/blob/main/antora-playbook.yml)
 
 ## LICENSE
 


### PR DESCRIPTION
I had a hard time figuring out what I was supposed to do to document an extension, so I've filled in the wiki with what I've been able to figure out. 

Sadly, it won't be indexed in the wiki, so it should perhaps live in https://quarkus.io/guides/writing-extensions#publish-your-extension-in-registry-quarkus-io, but that's #93. 