### PR TITLE
Publish hub (wiki) docs to site

### DIFF
--- a/.github/workflows/jekyll-gh-pages.yml
+++ b/.github/workflows/jekyll-gh-pages.yml
@@ -33,7 +33,7 @@ jobs:
       - name: Build with Jekyll
         uses: actions/jekyll-build-pages@v1
         with:
-          source: ./
+          source: ./docs
           destination: ./_site
       - name: Upload artifact
         uses: actions/upload-pages-artifact@v1


### PR DESCRIPTION
This is a little bit speculative, because GitHub does some magic with its default Jekyll publication, and I don't totally know how much magic we get. 

If I test this change locally, I get 

<img width="1494" alt="image" src="https://github.com/quarkiverse/quarkiverse/assets/11509290/2b4d48cc-d471-4d86-95b8-70f5350659ef">

on the other hand, if I test the current site locally, I get this:

<img width="1509" alt="image" src="https://github.com/quarkiverse/quarkiverse/assets/11509290/4571d0e7-423e-4f9e-861d-6a34f61bdff5">

... and what's getting published from this is actually much nicer. I'm hoping the same magic gets applied to the folder of markdown. 

 In the medium term I will implement proper static site generation, either using Gatsby, or Jekyll, or JBake, or something else ... and also surge previews so we don't have to do speculative merges to see what happens. :) In the short term, I'm hoping this small change will get content published. If it doesn't, I think consequences are low.  