### PR TITLE
Fix broken GitHub pages

### DIFF
--- a/.github/workflows/build_and_publish.yml
+++ b/.github/workflows/build_and_publish.yml
@@ -58,19 +58,16 @@ jobs:
     # Only try and deploy on merged code
     if: "github.repository == 'quarkiverse/quarkiverse' && github.ref_name == 'main' && (github.event_name == 'push' || github.event_name == 'schedule' || github.event_name == 'workflow_dispatch')"
     needs: [ unit-test, build ]
+    permissions:
+      contents: write
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-node@v3
+      - name: Download Built site
+        uses: dawidd6/action-download-artifact@v2
         with:
-          node-version: '18'
-      - run: npm install
-      - uses: enriikke/gatsby-gh-pages-action@v2
+          name: site
+          path: site
+      - name: Deploy
+        uses: JamesIves/github-pages-deploy-action@v4
         with:
-          access-token: ${{ secrets.ACCESS_TOKEN }}
-          deploy-branch: pages
-          gatsby-args: --prefix-paths
-        env:
-          NODE_ENV: production
-          GATSBY_ACTIVE_ENV: production
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          folder: site # The folder the action should deploy.


### PR DESCRIPTION
The workflow we're using needs a access token as a secret, which is a nuisance. We can use a workflow for publishing which (a) does not rebuild and (b) does not need an access token.

As with the first, breaking, change, we can only really see if this is successful post-merge. 

We may also need to do something to add `--path-prefix` to the gatsby build conditionally, because I think it's needed for publish, but not for preview. But I might be wrong about that, so I will check it live before I do the work.