### PR TITLE
Fix broken links in navigation

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -22,6 +22,7 @@
         "prismjs": "^1.29.0",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
+        "slugify": "^1.6.6",
         "styled-components": "^6.0.3"
       },
       "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "prismjs": "^1.29.0",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
+    "slugify": "^1.6.6",
     "styled-components": "^6.0.3"
   },
   "devDependencies": {

--- a/plugins/gatsby-frontmatter-defaults/gatsby-node.js
+++ b/plugins/gatsby-frontmatter-defaults/gatsby-node.js
@@ -3,44 +3,44 @@
  * Instead, infer some sensible defaults.
  */
 
+const slugify = require("slugify");
 const defaultOptions = {
-  nodeType: "MarkdownRemark"
+    nodeType: "MarkdownRemark"
 };
 
-exports.onCreateNode = ({ node, getNode, actions }, pluginOptions) => {
-  const { createNodeField } = actions;
+exports.onCreateNode = ({node, getNode, actions}, pluginOptions) => {
+    const {createNodeField} = actions;
 
-  const options = {
-    ...defaultOptions,
-    ...pluginOptions
-  };
+    const options = {
+        ...defaultOptions,
+        ...pluginOptions
+    };
 
-  if (node.internal.type !== options.nodeType) {
-    return;
-  }
+    if (node.internal.type !== options.nodeType) {
+        return;
+    }
 
+    const {frontmatter, parent} = node;
+    const expandedParent = getNode(parent);
+    const {name} = expandedParent;
 
-  const { frontmatter, parent } = node;
-  const expandedParent = getNode(parent);
-  const {name} = expandedParent;
+    const {title, slug} = frontmatter;
 
-  const { title, slug } = frontmatter;
+    const fallbackSlug = slugify(name.replace(/\./g, '-'), {lower: true, remove: /:/});
+    const fallbackTitle = name?.replace(/-/g, " ");
 
-  const fallbackSlug = name?.toLowerCase();
-  const fallbackTitle = name?.replace(/-/g, " ");
+    const nonNullSlug = slug ? slug : fallbackSlug;
+    const nonNullTitle = title ? title : fallbackTitle;
 
-  const nonNullSlug = slug ? slug : fallbackSlug;
-  const nonNullTitle = title ? title : fallbackTitle;
+    createNodeField({
+        node,
+        name: "slug",
+        value: nonNullSlug
+    });
 
-  createNodeField({
-    node,
-    name: "slug",
-    value: nonNullSlug
-  });
-
-  createNodeField({
-    node,
-    name: "title",
-    value: nonNullTitle
-  });
+    createNodeField({
+        node,
+        name: "title",
+        value: nonNullTitle
+    });
 };

--- a/plugins/gatsby-frontmatter-defaults/gatsby-node.test.js
+++ b/plugins/gatsby-frontmatter-defaults/gatsby-node.test.js
@@ -1,125 +1,159 @@
-const { onCreateNode } = require("./gatsby-node");
+const {onCreateNode} = require("./gatsby-node");
 
-const defaultName = "Some-Kebab-Case-String"
+const defaultName = "Some-Kebab-Case-String.a-dot"
 const defaultParent = {name: defaultName};
 
 
-const createNodeField = jest.fn(({ node, name, value }) => {
-  node.fields[name] = value;
+const createNodeField = jest.fn(({node, name, value}) => {
+    node.fields[name] = value;
 });
 
 const getNode = jest.fn(() => {
-  return defaultParent;
+    return defaultParent;
 });
 
-const actions = { createNodeField };
+const actions = {createNodeField};
 
 describe("the frontmatter defaulter", () => {
-  describe("for a node with an existing slug", () => {
-    const slug = "Someone and Their Friend";
+    describe("for a node with an existing slug", () => {
+        const slug = "Someone and Their Friend";
 
-    const fields = {};
-    const frontmatter = {
-      slug
-    };
+        const fields = {};
+        const frontmatter = {
+            slug
+        };
 
-    const node = {
-      fields,
-      frontmatter,
-      internal: { type: "MarkdownRemark" }
-    };
+        const node = {
+            fields,
+            frontmatter,
+            internal: {type: "MarkdownRemark"}
+        };
 
-    beforeAll(async () => {
-      await onCreateNode({ node, getNode, actions });
+        beforeAll(async () => {
+            await onCreateNode({node, getNode, actions});
+        });
+
+        afterAll(() => {
+        });
+
+        it("leaves the original", async () => {
+            expect(frontmatter.slug).toEqual(slug);
+        });
+
+        it("copies the slug to the fields", async () => {
+            expect(fields.slug).toEqual(slug);
+        });
     });
 
-    afterAll(() => {});
+    describe("for a node with an existing slug", () => {
+        const slug = "Someone and Their Friend";
 
-    it("leaves the original", async () => {
-      expect(frontmatter.slug).toEqual(slug);
+        const fields = {};
+        const frontmatter = {
+            slug
+        };
+
+        const node = {
+            fields,
+            frontmatter,
+            internal: {type: "MarkdownRemark"}
+        };
+
+        beforeAll(async () => {
+            await onCreateNode({node, getNode, actions});
+        });
+
+        afterAll(() => {
+        });
+
+        it("leaves the original", async () => {
+            expect(frontmatter.slug).toEqual(slug);
+        });
+
+        it("copies the slug to the fields", async () => {
+            expect(fields.slug).toEqual(slug);
+        });
     });
 
-    it("copies the slug to the fields", async () => {
-      expect(fields.slug).toEqual(slug);
-    });
-  });
+    describe("for a node with no slug", () => {
+        const fields = {};
+        const frontmatter = {};
 
-  describe("for a node with no slug", () => {
-    const fields = {};
-    const frontmatter = {};
+        const node = {
+            fields,
+            frontmatter,
+            internal: {type: "MarkdownRemark"}
+        };
 
-    const node = {
-      fields,
-      frontmatter,
-      internal: { type: "MarkdownRemark" }
-    };
+        beforeAll(async () => {
+            await onCreateNode({node, getNode, actions});
+        });
 
-    beforeAll(async () => {
-      await onCreateNode({ node, getNode, actions });
-    });
+        afterAll(() => {
+        });
 
-    afterAll(() => {});
+        it("does not change the frontmatter", async () => {
+            expect(frontmatter).toEqual({});
+        });
 
-    it("does not change the frontmatter", async () => {
-      expect(frontmatter).toEqual({});
-    });
-
-    it("copies the site slug to the fields ", async () => {
-      expect(fields.slug).toEqual("some-kebab-case-string");
-    });
-  });
-
-  describe("for a node with an existing title", () => {
-    const title = "Someone and Their Friend";
-
-    const fields = {};
-    const frontmatter = {
-      title
-    };
-
-    const node = {
-      fields,
-      frontmatter,
-      internal: { type: "MarkdownRemark" }
-    };
-
-    beforeAll(async () => {
-      await onCreateNode({ node, getNode, actions });
+        it("turns the page name into a slug", async () => {
+            expect(fields.slug).toEqual("some-kebab-case-string-a-dot");
+        });
     });
 
-    afterAll(() => {});
+    describe("for a node with an existing title", () => {
+        const title = "Someone and Their Friend";
 
-    it("leaves the original", async () => {
-      expect(frontmatter.title).toEqual(title);
+        const fields = {};
+        const frontmatter = {
+            title
+        };
+
+        const node = {
+            fields,
+            frontmatter,
+            internal: {type: "MarkdownRemark"}
+        };
+
+        beforeAll(async () => {
+            await onCreateNode({node, getNode, actions});
+        });
+
+        afterAll(() => {
+        });
+
+        it("leaves the original", async () => {
+            expect(frontmatter.title).toEqual(title);
+        });
+
+        it("copies the title to the fields", async () => {
+            expect(fields.title).toEqual(title);
+        });
     });
 
-    it("copies the title to the fields", async () => {
-      expect(fields.title).toEqual(title);
+    describe("for a node with no title", () => {
+        const fields = {};
+        const frontmatter = {};
+
+        const node = {
+            fields,
+            frontmatter,
+            internal: {type: "MarkdownRemark"}
+        };
+
+        beforeAll(async () => {
+            await onCreateNode({node, getNode, actions});
+        });
+
+        afterAll(() => {
+        });
+
+        it("does not change the frontmatter", async () => {
+            expect(frontmatter).toEqual({});
+        });
+
+        it("copies the a human readable site title to the fields", async () => {
+            expect(fields.title).toEqual("Some Kebab Case String.a dot");
+        });
     });
-  });
-
-  describe("for a node with no title", () => {
-    const fields = {};
-    const frontmatter = {};
-
-    const node = {
-      fields,
-      frontmatter,
-      internal: { type: "MarkdownRemark" }
-    };
-
-    beforeAll(async () => {
-      await onCreateNode({ node, getNode, actions });
-    });
-
-    afterAll(() => {});
-
-    it("does not change the frontmatter", async () => {
-      expect(frontmatter).toEqual({});
-    });
-
-    it("copies the a human readable site title to the fields", async () => {
-      expect(fields.title).toEqual("Some Kebab Case String");
-    });
-  });
 });


### PR DESCRIPTION
Some of the wiki pages have titles involving '.' or ':' (especially the "Migrating to X" ones), and those are dead links.

It looks like the Gatsby page names will not have dots in them, even if there's a dot in the slug, so we should adjust generated slugs to avoid the conflict. We can do it manually, but using a library is probably safer. Sadly, slugify allows dots, which is the whole problem we're trying to fix so we still need to strip them manually. Slugify also passes through colons, so we need to configure it to remove them. Still, using it should give us some extra safety.

Some whitespace changes crept into this PR, sorry.