### PR TITLE
Fix broken links

### DIFF
--- a/.github/workflows/build_and_publish.yml
+++ b/.github/workflows/build_and_publish.yml
@@ -43,6 +43,7 @@ jobs:
           NODE_ENV: production
           GATSBY_ACTIVE_ENV: production
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PREFIX_PATHS: true
       - run: npm run test:int
         env:
           CI: true

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -17,6 +17,7 @@ jobs:
           workflow: ${{ github.event.workflow_run.workflow_id }}
           workflow_conclusion: success
           name: site
+          path: quarkiverse
       - name: Store PR id as variable
         id: pr
         run: |
@@ -30,7 +31,7 @@ jobs:
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           body: |
-            🚀 PR Preview ${{ github.sha }} has been successfully built and deployed to https://hub-quarkiverse-pr-${{ steps.pr.outputs.id }}-preview.surge.sh
+            🚀 PR Preview ${{ github.sha }} has been successfully built and deployed to https://hub-quarkiverse-pr-${{ steps.pr.outputs.id }}-preview.surge.sh/quarkiverse
             <!-- Sticky Pull Request Comment -->
           body-include: '<!-- Sticky Pull Request Comment -->'
           number: ${{ steps.pr.outputs.id }}

--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -8,6 +8,8 @@
  * @type {import('gatsby').GatsbyConfig}
  */
 module.exports = {
+  // remove or update this once the URL is finalised and we add a cname
+  pathPrefix: `/quarkiverse`,
   siteMetadata: {
     title: `Quarkiverse Hub`,
     description: `The Quarkiverse Hub provides support for Quarkus extension projects contributed by the community.`,


### PR DESCRIPTION
It looks like a recent change, probably #129, broke links in production (argh, etc). It's a bit tricky because production and the surge preview have different behaviour. I've configured gatsby to handle the prefix path, which I didn't do before because it would break surge. I've tried to configure surge to also have the same prefix so we can test behaviour better, although we won't know if that works until post-merge.