### PR TITLE
Add CNAME into published source tree

### DIFF
--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -17,11 +17,10 @@ jobs:
           workflow: ${{ github.event.workflow_run.workflow_id }}
           workflow_conclusion: success
           name: site
-          path: quarkiverse
       - name: Store PR id as variable
         id: pr
         run: |
-          echo "id=$(<quarkiverse/pr-id.txt)" >> $GITHUB_OUTPUT 
+          echo "id=$(<pr-id.txt)" >> $GITHUB_OUTPUT 
           rm -f pr-id.txt
       - name: Publishing to surge for preview
         id: deploy
@@ -31,7 +30,7 @@ jobs:
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           body: |
-            🚀 PR Preview ${{ github.sha }} has been successfully built and deployed to https://hub-quarkiverse-pr-${{ steps.pr.outputs.id }}-preview.surge.sh/quarkiverse
+            🚀 PR Preview ${{ github.sha }} has been successfully built and deployed to https://hub-quarkiverse-pr-${{ steps.pr.outputs.id }}-preview.surge.sh
             <!-- Sticky Pull Request Comment -->
           body-include: '<!-- Sticky Pull Request Comment -->'
           number: ${{ steps.pr.outputs.id }}

--- a/docs/Home.md
+++ b/docs/Home.md
@@ -1,4 +1,4 @@
-# Welcome to Quarkiverse!
+# Welcome to the Quarkiverse Hub!
 
 **NOTE** this content is still a draft - feedback welcome!
 
@@ -10,11 +10,9 @@ Quarkiverse is our proposed solution to create a "home" for such extensions/proj
 
 # What is Quarkiverse
 
-This Quarkiverse GitHub organization provides repository hosting (including build, CI and release publishing setup) for Quarkus extension projects contributed by the community.
+The [Quarkiverse GitHub organization](http://github.com/quarkiverse) provides repository hosting (including build, CI and release publishing setup) for Quarkus extension projects contributed by the community.
 
-Quarkus extensions hosted in the Quarkiverse organization will eventually by default be included into the Quarkus extensions catalog available on [code.quarkus.io](http://code.quarkus.io) and the Quarkus command line tools (such as `mvn quarkus:list-extensions`, `gradle listExtensions`). To stay listed, the only requirement is that the extension keeps functioning, stays up-to-date and cause no harm.
-
-Note: the inclusion in tools are an ongoing development. Estimated to happen after April/May 2021.
+Quarkus extensions hosted in the Quarkiverse organization will can easily be included into the Quarkus extensions catalog available on [code.quarkus.io](http://code.quarkus.io) and the Quarkus command line tools (such as `mvn quarkus:list-extensions`, `gradle listExtensions`). To stay listed, the only requirement is that the extension keeps functioning, stays up-to-date and cause no harm.
 
 # Why Quarkiverse
 

--- a/docs/Home.md
+++ b/docs/Home.md
@@ -12,7 +12,7 @@ Quarkiverse is our proposed solution to create a "home" for such extensions/proj
 
 The [Quarkiverse GitHub organization](http://github.com/quarkiverse) provides repository hosting (including build, CI and release publishing setup) for Quarkus extension projects contributed by the community.
 
-Quarkus extensions hosted in the Quarkiverse organization will can easily be included into the Quarkus extensions catalog available on [code.quarkus.io](http://code.quarkus.io) and the Quarkus command line tools (such as `mvn quarkus:list-extensions`, `gradle listExtensions`). To stay listed, the only requirement is that the extension keeps functioning, stays up-to-date and cause no harm.
+Quarkus extensions hosted in the Quarkiverse organization can easily be included into the Quarkus extensions catalog available on [code.quarkus.io](http://code.quarkus.io) and the Quarkus command line tools (such as `mvn quarkus:list-extensions`, `gradle listExtensions`). To stay listed, the only requirement is that the extension keeps functioning, stays up-to-date and cause no harm.
 
 # Why Quarkiverse
 

--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -8,47 +8,45 @@
  * @type {import('gatsby').GatsbyConfig}
  */
 module.exports = {
-  // remove or update this once the URL is finalised and we add a cname
-  pathPrefix: `/quarkiverse`,
-  siteMetadata: {
-    title: `Quarkiverse Hub`,
-    description: `The Quarkiverse Hub provides support for Quarkus extension projects contributed by the community.`,
-    author: `@quarkusio`,
-    siteUrl: `https://quarkiverse.io/quarkiverse`,
-  },
-  plugins: [
-    {
-      resolve: `gatsby-source-filesystem`,
-      options: {
-        name: `content`,
-        path: `${__dirname}/docs`,
-      },
+    siteMetadata: {
+        title: `Quarkiverse Hub`,
+        description: `The Quarkiverse Hub provides support for Quarkus extension projects contributed by the community.`,
+        author: `@quarkusio`,
+        siteUrl: `https://hub.quarkiverse.io`,
     },
-    `gatsby-transformer-remark`,
-    "gatsby-frontmatter-defaults",
-    `gatsby-plugin-image`,
-    {
-      resolve: `gatsby-source-filesystem`,
-      options: {
-        name: `images`,
-        path: `${__dirname}/src/images`,
-      },
-    },
-    `gatsby-transformer-sharp`,
-    `gatsby-plugin-sharp`,
-    {
-      resolve: `gatsby-plugin-manifest`,
-      options: {
-        name: `gatsby-starter-default`,
-        short_name: `starter`,
-        start_url: `/`,
-        background_color: `#663399`,
-        // This will impact how browsers show your PWA/website
-        // https://css-tricks.com/meta-theme-color-and-trickery/
-        // theme_color: `#663399`,
-        display: `minimal-ui`,
-        icon: `src/images/quarkiverse-logo.png`, // This path is relative to the root of the site.
-      },
-    },
-  ],
+    plugins: [
+        {
+            resolve: `gatsby-source-filesystem`,
+            options: {
+                name: `content`,
+                path: `${__dirname}/docs`,
+            },
+        },
+        `gatsby-transformer-remark`,
+        "gatsby-frontmatter-defaults",
+        `gatsby-plugin-image`,
+        {
+            resolve: `gatsby-source-filesystem`,
+            options: {
+                name: `images`,
+                path: `${__dirname}/src/images`,
+            },
+        },
+        `gatsby-transformer-sharp`,
+        `gatsby-plugin-sharp`,
+        {
+            resolve: `gatsby-plugin-manifest`,
+            options: {
+                name: `gatsby-starter-default`,
+                short_name: `starter`,
+                start_url: `/`,
+                background_color: `#663399`,
+                // This will impact how browsers show your PWA/website
+                // https://css-tricks.com/meta-theme-color-and-trickery/
+                // theme_color: `#663399`,
+                display: `minimal-ui`,
+                icon: `src/images/quarkiverse-logo.png`, // This path is relative to the root of the site.
+            },
+        },
+    ],
 }

--- a/src/static/CNAME
+++ b/src/static/CNAME
@@ -1,0 +1,1 @@
+hub.quarkus.io

--- a/src/static/CNAME
+++ b/src/static/CNAME
@@ -1,1 +1,1 @@
-hub.quarkus.io
+hub.quarkiverse.io


### PR DESCRIPTION
Now that http://hub.quarkiverse.io is live 🎁 🎉 ... we need to make sure it stays that way by putting a CNAME into the deployed tree. I've also updated the site config to reflect the new URL, and the preview logic to not put `/quarkiverse` into the surge path. I think that means links will be broken in this preview, but should be working once it's merged.

While I was making the config change, I spotted a few little content things in the home text. (It could do with a more thorough review, but that can come later.)