### PR TITLE
Support markdown-style emojis, remove 'home' heading on home page

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -21,8 +21,14 @@ module.exports = {
                 name: `content`,
                 path: `${__dirname}/docs`,
             },
+        }, {
+            resolve: `gatsby-transformer-remark`,
+            options: {
+                plugins: [
+                    `gatsby-remark-emoji`,
+                ]
+            },
         },
-        `gatsby-transformer-remark`,
         "gatsby-frontmatter-defaults",
         `gatsby-plugin-image`,
         {

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,6 +18,7 @@
         "gatsby-plugin-image": "^3.11.0",
         "gatsby-plugin-manifest": "^5.11.0",
         "gatsby-plugin-sharp": "^5.11.0",
+        "gatsby-remark-emoji": "^0.0.3",
         "gatsby-remark-prismjs": "^7.11.0",
         "gatsby-source-filesystem": "^5.11.0",
         "gatsby-transformer-remark": "^6.11.0",
@@ -9236,6 +9237,11 @@
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-9.2.2.tgz",
       "integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg=="
     },
+    "node_modules/emojione": {
+      "version": "3.1.7",
+      "resolved": "https://registry.npmjs.org/emojione/-/emojione-3.1.7.tgz",
+      "integrity": "sha512-ITb0rrx6iuJKBnThRUE0uiGkwriwnY+919vxsAF+EqBHXhyjCTAcUo/nPNWodHaOJvKGdI1mel2o6TyyxBjjLw=="
+    },
     "node_modules/emojis-list": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/emojis-list/-/emojis-list-3.0.0.tgz",
@@ -11818,6 +11824,15 @@
         "@gatsbyjs/reach-router": "^2.0.0",
         "react": "^18.0.0 || ^0.0.0",
         "react-dom": "^18.0.0 || ^0.0.0"
+      }
+    },
+    "node_modules/gatsby-remark-emoji": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/gatsby-remark-emoji/-/gatsby-remark-emoji-0.0.3.tgz",
+      "integrity": "sha512-j4G3DeTop68MIR+lZ3lB+jsYV4FwmoE/Rpz5Z5lir1nQmf1DPAVeMzuTvLidKDvWBWSuJnwBV3Wzx9NeXnznSQ==",
+      "dependencies": {
+        "bluebird": "^3.5.0",
+        "emojione": "^3.1.2"
       }
     },
     "node_modules/gatsby-remark-prismjs": {

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "gatsby-plugin-image": "^3.11.0",
     "gatsby-plugin-manifest": "^5.11.0",
     "gatsby-plugin-sharp": "^5.11.0",
+    "gatsby-remark-emoji": "^0.0.3",
     "gatsby-remark-prismjs": "^7.11.0",
     "gatsby-source-filesystem": "^5.11.0",
     "gatsby-transformer-remark": "^6.11.0",

--- a/src/pages/index.jsx
+++ b/src/pages/index.jsx
@@ -7,7 +7,7 @@ const HomePage = ({data}) => {
     const {fields, html} = markdownRemark
     return (
         <Layout pageName={fields.pageName}>
-            <h1>{fields.title}</h1>
+            {/*No title here, since it will be 'home'*/}
             <div
                 dangerouslySetInnerHTML={{__html: html}}
             />


### PR DESCRIPTION
What's changed: 
- Support for markdown emojis
- Removal of unhelpful 'Home' heading on home page

## Admonitions 

I spent ages trying to figure out what admonition syntax the wiki was using, to resolve visual problems like this: 

<img width="687" alt="image" src="https://github.com/quarkiverse/quarkiverse/assets/11509290/1ea38cc8-1e91-4b65-b3c4-4d42d981a0db">

then I eventually [realised](https://stackoverflow.com/questions/50544499/how-to-make-a-styled-markdown-admonition-box-in-a-github-gist) that it was just an emoji. The combination of quoting and an emoji makes a home-rolled admonition effect. 

It would be nice to support admonitions, using something like https://www.gatsbyjs.com/plugins/gatsby-remark-admonitions/, but that would break wiki compatibility, so I won’t consider it now. It would also be possible to detect quote+emoji and apply more sophisticated styling.

## Headings

I removed the 'Home' heading on the front page, because it looked silly:

<img width="806" alt="image" src="https://github.com/quarkiverse/quarkiverse/assets/11509290/8f85eaaf-ea3c-48e2-aecd-3c8d6f68a76d">

For the moment, I left it on the other pages. The headings have value on most pages, but we need to bump the 'level' of all the other pages down one so we don't get things like this: 

<img width="867" alt="image" src="https://github.com/quarkiverse/quarkiverse/assets/11509290/7458dea6-07d4-428c-9b03-de19c1019f56">

I haven't done that in this work item, though. 

