### PR TITLE
Store opt-ins for naming companies as sponsors on extensions.quarkus.io

### DIFF
--- a/.github/named-contributor-opt-in.yml
+++ b/.github/named-contributor-opt-in.yml
@@ -1,0 +1,6 @@
+# This file is to record opt-ins for companies and organisations to be listed as sponsors and contributors on extension pages
+# See https://quarkus.io/extensions/io.quarkus/quarkus-resteasy-reactive for an example of what is shown
+
+# Including a company in this list should be done (or approved) by someone from that company
+named-sponsors:
+  - Red Hat


### PR DESCRIPTION
See https://github.com/quarkusio/extensions/pull/283 for context. 

We want to automatically display extensions sponsors on http://quarkus.io/extensions, but we do not want to list a company as a sponsor if they don't want to be listed! (We will do [something similar](https://github.com/quarkusio/extensions/issues/297) for contributing companies, and have the same requirement.)

The opt-in has to be global, rather than per-extension, or there's no point in having the automation. (We also have the ability for extension owners to set a sponsor in the extension metadata, but where possible we want to make things easier and less toil-ful.)

This repo seems like the most logical place to store opt-in information. 