### PR TITLE
Use official action for downloading artifacts

### DIFF
--- a/.github/workflows/build_and_publish.yml
+++ b/.github/workflows/build_and_publish.yml
@@ -66,7 +66,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3 # not needed for the code, but needed for the git config
       - name: Download Built site
-        uses: dawidd6/action-download-artifact@v2
+        uses: actions/download-artifact@v3
         with:
           name: site
           path: site


### PR DESCRIPTION
This is hard to test since we only exercise this code on the main branch, but I think we should use an official action rather than a third-party one. I saw some strange behaviour with the old action, where it didn't seem to be enforcing that downloads came from the same workflow, and so a user error seems to have allowed stale content from PRs (!) to be deployed to the live site (https://github.com/quarkusio/extensions/issues/337 has part of the story). 