### PR TITLE
Remove 'name' from example project.yml

### DIFF
--- a/docs/Release.md
+++ b/docs/Release.md
@@ -7,7 +7,6 @@ To perform a release, one must provide a Pull-request changing the `current-vers
 
 Example: 
 ```yaml
-name: Quarkiverse Parent
 release:
   current-version: "2"
   next-version: "999-SNAPSHOT"    


### PR DESCRIPTION
The `name` parameter in project.yml isn't needed. Having it there doesn't cause too much harm, but it's a bit WET, since the name is elsewhere, and it means people need to stop and think about choosing a suitable value.