### PR TITLE
Be more precise in the artifact we try to download

### DIFF
--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -12,9 +12,10 @@ jobs:
     if: github.event.workflow_run.event == 'pull_request' && github.event.workflow_run.conclusion == 'success'
     steps:
       - name: Download PR Artifact
-        uses: dawidd6/action-download-artifact@v2
+        uses: dawidd6/action-download-artifact@v6
         with:
           workflow: ${{ github.event.workflow_run.workflow_id }}
+          run_id: ${{ github.event.workflow_run.id }}
           workflow_conclusion: success
           name: site
       - name: Store PR id as variable


### PR DESCRIPTION
Version 4 of the dawidd6/actions-download-artifact would sometimes download the wrong artifact if a version wasn't specified. I think (based on looking at https://github.com/quarkiverse/quarkus-openapi-generator/blob/cdba833ae0fa5a905cfc10a875bfc9781cd5bdcd/.github/workflows/preview.yml#L15, which seems to be working ok), that is fixed in later versions. 

So it might be safe to update the version without adding the run id, but I think being more precise in specifying what run's artifact we want to download is a good thing, and avoids any risk of race conditions on the actions.