### PR TITLE
Remove double heading

### DIFF
--- a/docs/DocumentingYourExtension.md
+++ b/docs/DocumentingYourExtension.md
@@ -1,5 +1,3 @@
-# Documenting your extension
-
 ## Using Antora 
 
 The Quarkiverse extension template includes skeleton documentation. 


### PR DESCRIPTION
The title in the html is a bit awkward. The wiki shows it, so we have to show it too, or pages look like they have no title. But if pages set an h1 element themselves, it looks stupid.