### PR TITLE
No need for a path prefix in link checking

### DIFF
--- a/.github/workflows/build_and_publish.yml
+++ b/.github/workflows/build_and_publish.yml
@@ -97,8 +97,6 @@ jobs:
         continue-on-error: true # problems will be tracked by defects raised by the next job, not by build failures
         env:
           CI: true
-          PATH_PREFIX: "${{ github.ref_name == 'main' && 'quarkiverse' || '' }}"
-          PATH_PREFIX_FLAG: "${{ github.ref_name == 'main' && '--prefix-paths' || '' }}"
       - name: Raise defects if needed
         uses: jbangdev/jbang-action@v0.111.0
         if: "github.repository == 'quarkiverse/quarkiverse' && github.ref_name == 'main' && (github.event_name == 'push' || github.event_name == 'schedule' || github.event_name == 'workflow_dispatch')"

--- a/site/site-validation/external-links.test.js
+++ b/site/site-validation/external-links.test.js
@@ -26,7 +26,6 @@ describe("site external links", () => {
 
         // After a page is scanned, check out the results!
         checker.on("link", async result => {
-            console.log("Checking", result.url, "->", result.state, " on ", result.parent)
             if (result.state === "BROKEN") {
                 // Don't stress about 403s from vimeo because humans can get past the paywall fairly easily and we want to have the link
                 const isPaywalled =


### PR DESCRIPTION
This doesn't solve the problem of the github-api 403, but it should fix the issue where PRs failed correctly, and main then would pass incorrectly.