### PR TITLE
Sort out duplication of title and content between Quarkiverse wiki migration guide and Quarkus wiki migration guide

### DIFF
--- a/docs/Infrastructure-for-Quarkus-3.x.md
+++ b/docs/Infrastructure-for-Quarkus-3.x.md
@@ -1,29 +1,12 @@
+This guide is describes infrastructure change owners of extensions hosted in the Quarkiverse should make in preparation for major release updates.
+For normal extension migration, see the Quarkus migration guides.
+
 # What’s changing
 
 [Quarkus 3 is on the way](https://quarkus.io/blog/road-to-quarkus-3/), and it has breaking changes. 
 These changes will affect extensions, so extension maintainers should be prepared.
 
 Don't worry, we have a script that automates most (if not all) of the migration that works for applications... and extensions.
-
-# Known breakers
-
-## Jakarta EE 10 [released now]
-
-Quarkus is moving to use Jakarta EE 10 APIs instead of Jakarta EE 8 ones.
-In most cases the functionality isn’t different, but package names are.
-
-## Hibernate ORM 5 to 6 [released now]
-
-Quarkus 3 ships with Hibernate ORM 6 instead of Hibernate ORM 5. This is a major release, and so there are some breaking changes, especially if your extension uses the Criteria API. We don’t expect that many extensions rely on these, but in case you do, the Hibernate team have published a [full migration guide](https://github.com/quarkusio/quarkus/wiki/Migration-Guide-3.0:-Hibernate-ORM-5-to-6-migration).
-
-## Flow, instead of reactive streams [released now]
-
-Quarkus 3 uses the JDK Flow API introduced since Java 9 instead of the legacy Reactive Streams API.
-For a discussion of what changes were needed within Quarkus itself, see
-- https://groups.google.com/g/quarkus-dev/c/RpeqFv1dr8k
-- https://github.com/quarkusio/quarkus/issues/26675
-
-If your extension needs to use a library that is still using the legacy Reactive Streams API then you should use the adapters from the Mutiny Zero project (see https://smallrye.io/smallrye-mutiny-zero).
 
 # Are you affected?
 

--- a/docs/Infrastructure-for-Quarkus-3.x:-Manual-upgrade.md
+++ b/docs/Infrastructure-for-Quarkus-3.x:-Manual-upgrade.md
@@ -1,4 +1,7 @@
-:warning: First have a look at the automated process described [here](https://github.com/quarkiverse/quarkiverse/wiki/Migrating-to-Quarkus-3.x), using the manual upgrade should be last resort.
+This guide is intended for Quarkiverse extension owners who wish to test against early versions of Quarkus 3.0, before its release.
+For normal extension migration, see the Quarkus migration guides.
+
+:warning: First have a look at the automated process described [here](https://github.com/quarkiverse/quarkiverse/wiki/Infrastructure-Quarkus-3.x), using the manual upgrade should be last resort.
 
 If you’re not able to use the automation or some step is missed, you can manually move to the latest dependencies and patch up the code manually.
 But please take the time to report the issues you experienced to the Quarkus team so that they can improve the upgrade script appropriately.


### PR DESCRIPTION
For a while, I've been troubled by the fact that we have two rather similar 3.x migration guides, both with content for extension authors. One is https://github.com/quarkiverse/quarkiverse/wiki/Migrating-to-Quarkus-3.x and https://github.com/quarkiverse/quarkiverse/wiki/Migrating-to-Quarkus-3.x:-Manual-upgrade (plus mirrored content on http://hub.quarkiverse.io). The other is https://github.com/quarkusio/quarkus/wiki/Migration-Guide-3.0. Apparently the Quarkiverse pages are only supposed to be about Quarkiverse-specific concerns, so I've updated the names and content to reflect this.

- Remove content which should be on the main migration pages, since it is not specific to quarkiverse infrastructure. 
- Update page names to clarify the purpose.