### PR TITLE
Improve clarity of docs around registry inclusion and terraform

### DIFF
--- a/docs/ChecklistForNewProjects.md
+++ b/docs/ChecklistForNewProjects.md
@@ -50,7 +50,10 @@ In order to have your [extension documentation](https://github.com/quarkiverse/q
 
 ## [Make your extension available in the tooling](https://github.com/quarkusio/quarkus-extension-catalog#extensions)
 
-Create a `YAML` file with your extension's `group-id` and `artifact-id` in the [quarkus-extension-catalog repository](https://github.com/quarkusio/quarkus-extension-catalog/tree/main/extensions)  
+Most Quarkus extensions are listed in the [Quarkus community extension registry](https://quarkus.io/guides/extension-registry-user#registry.quarkus.io).
+Once extensions are included in the registry, they will automatically be available on [code.quarkus.io](https://code.quarkus.io), [extensions.quarkus.io](https://extensions.quarkus.io), and in the Quarkus command line tools (such as `mvn quarkus:list-extensions`, `gradle listExtensions`). 
+
+The community registry reads its contents from [quarkus-extension-catalog repository](https://github.com/quarkusio/quarkus-extension-catalog/tree/main/extensions). To add your extension to catalog, create a `YAML` file with your extension's `group-id` and `artifact-id` in the [extensions directory of the quarkus-extension-catalog repository](https://github.com/quarkusio/quarkus-extension-catalog/tree/main/extensions). 
 
 ## [Allow your company to be named as a sponsor or contributor (optional)](https://github.com/quarkusio/quarkus-extension-catalog#extensions)
 

--- a/docs/Home.md
+++ b/docs/Home.md
@@ -18,7 +18,6 @@ The advantages of joining Quarkiverse are:
 
 - Automated and secured publishing of your maven releases to Maven Central.
 - Automated Cross-testing of your extension with Quarkus builds/releases (see https://github.com/quarkusio/quarkus-ecosystem-ci)
-- Inclusion in registry used by Quarkus tooling to browse extensions (i.e. code.quarkus, command line and IDE tools).
 - Consistent formatting and release of project
 - Quarkus team members can in an emergency (i.e. maintainers are missing) help and fix issues.
 
@@ -47,6 +46,13 @@ The Quarkiverse team will provide the repository ready for development, neverthe
 
 All Quarkiverse extensions can include documentation on http://docs.quarkiverse.io. 
 See the [documentation about the documentation](documentingyourextension) for details on how how to document your extension.
+
+## Managing settings on the GitHub repository
+
+Extension maintainers have full control over the repository settings, but be aware that the settings are infrastructure as code, managed with Terraform. 
+To change any setting in the repository (give push permissions to anyone, enable a GitHub app, etc.), update the repository's `.tf` file. 
+You may notice that, even as an extension maintainer, you have restricted permissions in the GitHub UI. 
+This is to reduce the risk of accidents where maintainers make changes which then get overwritten by the next Terraform run.  
 
 ## Expectations for Quarkiverse projects 
 


### PR DESCRIPTION
This PR:
- Removes the line saying inclusion in the Quarkiverse org makes getting into the registry easier, because I don't think it actually does
- Adds an extra bit about how we use terraform on the main home page, to try and preempt concerns like https://github.com/quarkiverse/quarkus-couchbase/issues/96#issuecomment-2371561445
- Adds a bit more clarity about why extension authors might want to add themselves to the extension catalog. I still find I'm doing a lot of manual work proposing authors add themselves to the catalog. 