### PR TITLE
Downgrade to ubuntu-22 to fix puppeteer sandbox issue

### DIFF
--- a/.github/workflows/build_and_publish.yml
+++ b/.github/workflows/build_and_publish.yml
@@ -32,7 +32,7 @@ jobs:
         env:
           CI: true
   build:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4


### PR DESCRIPTION
See https://github.com/puppeteer/puppeteer/issues/12818

Builds have been failing for six months (oops). 