### PR TITLE
Update preview runner

### DIFF
--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -10,7 +10,7 @@ on:
 
 jobs:
   preview:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     if: github.event.workflow_run.event == 'pull_request' && github.event.workflow_run.conclusion == 'success'
     steps:
       - name: Download PR Artifact


### PR DESCRIPTION
Preview jobs are waiting 24 hours for a runner and then dying, because the image is too old. 